### PR TITLE
Improve trigger for settings menu

### DIFF
--- a/main.js
+++ b/main.js
@@ -26,6 +26,7 @@
 
     const css = `
     #bn-container { position: fixed; bottom: 20px; right: 20px; width: 260px; z-index: 10000; }
+    #bn-container.bn-collapsed { width: 32px; height: 32px; }
     #bn-container * { pointer-events: auto; }
     #bn-trigger { position: absolute; bottom: 0; right: 0; width: 32px; height: 32px; background: rgba(0,0,0,0.4); border-radius: 50%; display: flex; align-items: center; justify-content: center; color: #fff; font-size: 18px; cursor: pointer; transition: background 0.2s; }
     #bn-trigger:hover { background: rgba(0,0,0,0.6); }
@@ -79,6 +80,7 @@
       </div>`;
     document.body.appendChild(container);
     container.style.pointerEvents = 'none';
+    container.classList.add('bn-collapsed');
 
     const trigger  = document.getElementById('bn-trigger');
     const panel    = document.getElementById('bn-panel');
@@ -95,11 +97,13 @@
     const showPanel = () => {
         clearTimeout(hideTimer);
         panel.classList.add('bn-show');
+        container.classList.remove('bn-collapsed');
         container.style.pointerEvents = 'auto';
     };
     const hidePanel = () => {
         panel.classList.remove('bn-show');
         container.style.pointerEvents = 'none';
+        container.classList.add('bn-collapsed');
     };
     trigger.addEventListener('mouseenter', showPanel);
     trigger.addEventListener('mouseleave', () => {


### PR DESCRIPTION
## Summary
- limit hover area when menu is hidden
- show/hide panel toggles collapsed class so only the button triggers opening

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_b_687ce7b1e934832ab1c8222c75a3d6a2